### PR TITLE
[Migrated] Bring back line breaks in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Important Update
 
+TEST CHANGE
+
 > **Important**
 > Gloo Gateway is now a fully conformant Kubernetes Gateway API implementation!
 >


### PR DESCRIPTION
Issue has been moved to https://github.com/k8sgateway/k8sgateway/issues/2352